### PR TITLE
fix kubectl prefix

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,7 +46,7 @@ func Execute() {
 func execName() string {
 	n := "marvin"
 	if strings.HasPrefix(filepath.Base(os.Args[0]), "kubectl-") {
-		return "kubectl-" + n
+		return "kubectl " + n
 	}
 	return n
 }


### PR DESCRIPTION
## Description
Fix kubectl prefix in help message.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
