### PR TITLE
Add new check for workload in namespace default (#25)

### DIFF
--- a/checks.md
+++ b/checks.md
@@ -1,0 +1,37 @@
+# Checks Overview  
+
+In the table below, you can view all checks present on Marvin. Click on the #ID column item for more details about each check.
+
+| Framework        | # ID                                                                       | Severity | Message                                          |
+|------------------|---------------------------------------------------------------------------|----------|--------------------------------------------------------|
+| CIS Benchmarks   | [M-500](/internal/builtins/cis/M-500_default_namespace.yaml)             | Medium   | Workloads in default namespace                   |
+| General          | [M-400](/internal/builtins/general/M-400_image_tag_latest.yaml)          | Medium   | Image tagged latest                              |
+|                  | [M-401](/internal/builtins/general/M-401_unmanaged_pod.yaml)             | Low      | Unmanaged Pod                                    |
+|                  | [M-402](/internal/builtins/general/M-402_readiness_probe.yaml)           | Medium   | Readiness and startup probe not configured       |
+|                  | [M-403](/internal/builtins/general/M-403_liveness_probe.yaml)            | Medium   | Liveness probe not configured                    |
+|                  | [M-404](/internal/builtins/general/M-404_memory_requests.yaml)           | Medium   | Memory requests not specified                    |
+|                  | [M-405](/internal/builtins/general/M-405_cpu_requests.yaml)              | Medium   | CPU requests not specified                       |
+|                  | [M-406](/internal/builtins/general/M-406_memory_limit.yaml)              | Medium   | Memory not limited                               |
+|                  | [M-407](/internal/builtins/general/M-407_cpu_limit.yaml)                 | Medium   | CPU not limited                                  |
+| NSA-CISA         | [M-300](/internal/builtins/nsa/M-300_read_only_root_filesystem.yml)     | Low      | Root filesystem write allowed                    |
+| MITRE ATT&CK     | [M-200](/internal/builtins/mitre/M-200_allowed_registries.yml)          | Medium   | Image registry not allowed                       |
+|                  | [M-201](/internal/builtins/mitre/M-201_app_credentials.yml)              | High     | Application credentials stored in configuration files |
+|                  | [M-202](/internal/builtins/mitre/M-202_auto_mount_service_account.yml)  | Low      | Automounted service account token                 |
+|                  | [M-203](/internal/builtins/mitre/M-203_ssh.yml)                          | Low      | SSH server running inside container               |
+| PSS - Baseline   | [M-100](/internal/builtins/pss/baseline/M-100_host_process.yml)         | High     | Privileged access to the Windows node            |
+|                  | [M-101](/internal/builtins/pss/baseline/M-101_host_namespaces.yml)       | High     | Host namespaces                                  |
+|                  | [M-102](/internal/builtins/pss/baseline/M-102_privileged_containers.yml) | High     | Privileged container                             |
+|                  | [M-103](/internal/builtins/pss/baseline/M-103_capabilities.yml)           | High     | Insecure capabilities                            |
+|                  | [M-104](/internal/builtins/pss/baseline/M-104_host_path_volumes.yml)     | High     | HostPath volume                                  |
+|                  | [M-105](/internal/builtins/pss/baseline/M-105_host_ports.yml)            | High     | Not allowed hostPort                             |
+|                  | [M-106](/internal/builtins/pss/baseline/M-106_apparmor.yml)              | Medium   | Forbidden AppArmor profile                       |
+|                  | [M-107](/internal/builtins/pss/baseline/M-107_selinux.yml)               | Medium   | Forbidden SELinux options                        |
+|                  | [M-108](/internal/builtins/pss/baseline/M-108_proc_mount.yml)            | Medium   | Forbidden proc mount type                        |
+|                  | [M-109](/internal/builtins/pss/baseline/M-109_seccomp.yml)               | Medium   | Forbidden seccomp profile                        |
+|                  | [M-110](/internal/builtins/pss/baseline/M-110_sysctls.yml)               | Medium   | Unsafe sysctls                                   |
+| PSS - Restricted | [M-111](/internal/builtins/pss/restricted/M-111_volume_types.yml)        | Low      | Not allowed volume type                          |
+|                  | [M-112](/internal/builtins/pss/restricted/M-112_privilege_escalation.yml)| Medium  | Allowed privilege escalation                     |
+|                  | [M-113](/internal/builtins/pss/restricted/M-113_run_as_non_root.yml)     | Medium   | Container could be running as root user          |
+|                  | [M-114](/internal/builtins/pss/restricted/M-114_run_as_user.yml)         | Low      | Container running as root UID                    |
+|                  | [M-115](/internal/builtins/pss/restricted/M-115_seccomp.yml)             | Low      | Not allowed seccomp profile                      |
+|                  | [M-116](/internal/builtins/pss/restricted/M-116_capabilities.yml)         | Low      | Not allowed added/dropped capabilities           |

--- a/internal/builtins/cis/M-500_default_namespace.yaml
+++ b/internal/builtins/cis/M-500_default_namespace.yaml
@@ -1,0 +1,46 @@
+# Copyright 2023 Undistro Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+id: M-500
+severity: Medium
+message: "Workloads in default namespace"
+match:
+  resources:
+    - group: ""
+      version: v1
+      resource: pods
+    - group: apps
+      version: v1
+      resource: deployments
+    - group: apps
+      version: v1
+      resource: daemonsets
+    - group: apps
+      version: v1
+      resource: statefulsets
+    - group: apps
+      version: v1
+      resource: replicasets
+    - group: batch
+      version: v1
+      resource: cronjobs
+    - group: batch
+      version: v1
+      resource: jobs
+validations:
+  - expression: >
+     has(object.metadata.namespace)
+     && (type(object.metadata.namespace) == string)
+     && !(object.metadata.namespace == 'default')

--- a/internal/builtins/cis/M-500_default_namespace_test.yaml
+++ b/internal/builtins/cis/M-500_default_namespace_test.yaml
@@ -1,0 +1,80 @@
+# Copyright 2023 Undistro Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: "Namespace set to default"
+  pass: false
+  input: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: nginx
+      namespace: default
+    spec:
+      template:
+        metadata:
+          name: nginx
+          labels:
+            app: nginx
+        spec:
+          containers:
+            - name: nginx
+              image: nginx
+      selector:
+        matchLabels:
+          app: nginx
+
+- name: "Namespace not specified"
+  pass: false
+  input: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: nginx
+    spec:
+      template:
+        metadata:
+          name: nginx
+          labels:
+            app: nginx
+        spec:
+          volumes: []
+          containers:
+            - name: nginx
+              image: nginx
+      selector:
+        matchLabels:
+          app: nginx
+
+- name: "Namespace specified"
+  pass: true
+  input: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: nginx
+      namespace: fooserver
+    spec:
+      template:
+        metadata:
+          name: nginx
+          labels:
+            app: nginx
+        spec:
+          volumes: []
+          containers:
+            - name: nginx
+              image: nginx
+      selector:
+        matchLabels:
+          app: nginx

--- a/pkg/loader/builtin_test.go
+++ b/pkg/loader/builtin_test.go
@@ -23,5 +23,5 @@ import (
 func TestBuiltins(t *testing.T) {
 	assert.NotNil(t, Builtins)
 	assert.Greater(t, len(Builtins), 0)
-	assert.Equal(t, len(Builtins), 30)
+	assert.Equal(t, len(Builtins), 31)
 }


### PR DESCRIPTION
## Description

1. Created a table for centralize all checks presents on the Marvin. 
2. Added new check for namespace should not be used related with [CIS documentation](https://learn.cisecurity.org/l/799323/2023-09-29/4t7mbj?_gl=1*pteanf*_ga*OTY1NTk0ODMyLjE3MDA3NjgzODQ.*_ga_3FW1B1JC98*MTcwMTExNDUwMC40LjAuMTcwMTExNDUwOS4wLjAuMA..*_ga_N70Z2MKMD7*MTcwMTExNDUwMC40LjAuMTcwMTExNDUwOS41MS4wLjA.) page 282. 

## How has this been tested?
Run make test

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [x] My changes are covered by tests
