### PR TITLE
Checks for sudo in entrypoint end registry deprecated 

### DIFF
--- a/checks.md
+++ b/checks.md
@@ -1,9 +1,10 @@
 # Checks Overview  
 
-The table below, we can see all checks present on Marvin.   
+The table below, we can see all checks presents on Marvin.
 
 | Framework | # ID        | Severity | Message              |
 |-----------|:-------------:|:----------:|----------------------|
+| CIS     |[M-500](/internal/builtins/cis/M-500_default_namespace.yaml)|Medium|The default namespace should not be used|
 | General | [M-400](/internal/builtins/general/M-400_image_tag_latest.yaml) |  Medium  |Image tagged latest| 
 |         | [M-401](/internal/builtins/general/M-401_unmanaged_pod.yaml)| Low | Unmanaged Pod|      
 |         | [M-402](/internal/builtins/general/M-402_readiness_probe.yaml)|Medium |Readiness and startup probe not configured| 
@@ -18,15 +19,20 @@ The table below, we can see all checks present on Marvin.
 |         |[M-202](/internal/builtins/mitre/M-202_auto_mount_service_account.yml)|Low|Automounted service account token|
 |         |[M-203](/internal/builtins/mitre/M-203_ssh.yml)| Low |SSH server running inside container|
 |         |                                                                    |     |        |
-| PSS - Basline|[M100](/internal/builtins/pss/baseline/M-100_host_process.yml)|High|Privileged access to the Windows node|
-|         |[M101](/internal/builtins/pss/baseline/M-101_host_namespaces.yml)|High|Host namespaces|
-|         |[M102](/internal/builtins/pss/baseline/M-102_privileged_containers.yml)|High|Privileged container|
-|         |[M103](/internal/builtins/pss/baseline/M-103_capabilities.yml)|High|Insecure capabilities|
-|         |[M104](/internal/builtins/pss/baseline/M-104_host_path_volumes.yml)|High|HostPath volume|
-|         |[M105](/internal/builtins/pss/baseline/M-105_host_ports.yml)|High|Not allowed hostPort|
-|         |[M106](/internal/builtins/pss/baseline/M-106_apparmor.yml)|Medium|Forbidden AppArmor profile|
-|         |[M107](/internal/builtins/pss/baseline/M-107_selinux.yml)|Medium|Forbidden SELinux options|
-|         |[M108](/internal/builtins/pss/baseline/M-108_proc_mount.yml)|Medium|Forbidden proc mount type|
-|         |[M109](/internal/builtins/pss/baseline/M-109_seccomp.yml)|Medium|Forbidden seccomp profile|
-|         |[M110](/internal/builtins/pss/baseline/M-110_sysctls.yml)|Medium|Unsafe sysctls|
-| CIS     |           |          |                      | | 
+| PSS - Basline|[M-100](/internal/builtins/pss/baseline/M-100_host_process.yml)|High|Privileged access to the Windows node|
+|         |[M-101](/internal/builtins/pss/baseline/M-101_host_namespaces.yml)|High|Host namespaces|
+|         |[M-102](/internal/builtins/pss/baseline/M-102_privileged_containers.yml)|High|Privileged container|
+|         |[M-103](/internal/builtins/pss/baseline/M-103_capabilities.yml)|High|Insecure capabilities|
+|         |[M-104](/internal/builtins/pss/baseline/M-104_host_path_volumes.yml)|High|HostPath volume|
+|         |[M-105](/internal/builtins/pss/baseline/M-105_host_ports.yml)|High|Not allowed hostPort|
+|         |[M-106](/internal/builtins/pss/baseline/M-106_apparmor.yml)|Medium|Forbidden AppArmor profile|
+|         |[M-107](/internal/builtins/pss/baseline/M-107_selinux.yml)|Medium|Forbidden SELinux options|
+|         |[M-108](/internal/builtins/pss/baseline/M-108_proc_mount.yml)|Medium|Forbidden proc mount type|
+|         |[M-109](/internal/builtins/pss/baseline/M-109_seccomp.yml)|Medium|Forbidden seccomp profile|
+|         |[M-110](/internal/builtins/pss/baseline/M-110_sysctls.yml)|Medium|Unsafe sysctls|
+| PSS - Restricted|[M-111](/internal/builtins/pss/restricted/M-111_volume_types.yml)|Low|Not allowed volume type|
+|      |[M-112](/internal/builtins/pss/restricted/M-112_privilege_escalation.yml)|Medium|Allowed privilege escalation|
+|      |[M-113](/internal/builtins/pss/restricted/M-113_run_as_non_root.yml)|Medium|Container could be running as root user|
+|      |[M-114](/internal/builtins/pss/restricted/M-114_run_as_user.yml)|Low|Container running as root UID|
+|      |[M-115](/internal/builtins/pss/restricted/M-115_seccomp.yml)|Low|Not allowed seccomp profile|
+|      |[M-116](/internal/builtins/pss/restricted/M-116_capabilities.yml)|Low|Not allowed added/dropped capabilities|

--- a/checks.md
+++ b/checks.md
@@ -4,7 +4,7 @@ In the table below, you can view all checks present on Marvin. Click on the #ID 
 
 | Framework        | # ID                                                                       | Severity | Message                                          |
 |------------------|---------------------------------------------------------------------------|----------|--------------------------------------------------|
-| CIS Benchmarks   | [M-500](/internal/builtins/cis/M-500_default_namespace.yaml)             | Medium   | The default namespace should not be used          |
+| CIS Benchmarks   | [M-500](/internal/builtins/cis/M-500_default_namespace.yaml)             | Medium   | Workloads in default namespace                   |
 | General          | [M-400](/internal/builtins/general/M-400_image_tag_latest.yaml)          | Medium   | Image tagged latest                              |
 |                  | [M-401](/internal/builtins/general/M-401_unmanaged_pod.yaml)             | Low      | Unmanaged Pod                                    |
 |                  | [M-402](/internal/builtins/general/M-402_readiness_probe.yaml)           | Medium   | Readiness and startup probe not configured       |

--- a/checks.md
+++ b/checks.md
@@ -2,36 +2,40 @@
 
 In the table below, you can view all checks present on Marvin. Click on the #ID column item for more details about each check.
 
-| Framework        | # ID                                                                       | Severity | Message                                          |
-|------------------|---------------------------------------------------------------------------|----------|--------------------------------------------------------|
-| CIS Benchmarks   | [M-500](/internal/builtins/cis/M-500_default_namespace.yaml)             | Medium   | Workloads in default namespace                   |
-| General          | [M-400](/internal/builtins/general/M-400_image_tag_latest.yaml)          | Medium   | Image tagged latest                              |
-|                  | [M-401](/internal/builtins/general/M-401_unmanaged_pod.yaml)             | Low      | Unmanaged Pod                                    |
-|                  | [M-402](/internal/builtins/general/M-402_readiness_probe.yaml)           | Medium   | Readiness and startup probe not configured       |
-|                  | [M-403](/internal/builtins/general/M-403_liveness_probe.yaml)            | Medium   | Liveness probe not configured                    |
-|                  | [M-404](/internal/builtins/general/M-404_memory_requests.yaml)           | Medium   | Memory requests not specified                    |
-|                  | [M-405](/internal/builtins/general/M-405_cpu_requests.yaml)              | Medium   | CPU requests not specified                       |
-|                  | [M-406](/internal/builtins/general/M-406_memory_limit.yaml)              | Medium   | Memory not limited                               |
-|                  | [M-407](/internal/builtins/general/M-407_cpu_limit.yaml)                 | Medium   | CPU not limited                                  |
-| NSA-CISA         | [M-300](/internal/builtins/nsa/M-300_read_only_root_filesystem.yml)     | Low      | Root filesystem write allowed                    |
-| MITRE ATT&CK     | [M-200](/internal/builtins/mitre/M-200_allowed_registries.yml)          | Medium   | Image registry not allowed                       |
+
+
+| Framework        | #ID                                                                      | Severity  | Message                                              |
+|------------------|--------------------------------------------------------------------------|---------- |------------------------------------------------------|
+| CIS Benchmarks   | [M-500](/internal/builtins/cis/M-500_default_namespace.yaml)             | Medium   | Workloads in default namespace                        |
+| General          | [M-400](/internal/builtins/general/M-400_image_tag_latest.yaml)          | Medium   | Image tagged latest                                   |
+|                  | [M-401](/internal/builtins/general/M-401_unmanaged_pod.yaml)             | Low      | Unmanaged Pod                                         |
+|                  | [M-402](/internal/builtins/general/M-402_readiness_probe.yaml)           | Medium   | Readiness and startup probe not configured            |
+|                  | [M-403](/internal/builtins/general/M-403_liveness_probe.yaml)            | Medium   | Liveness probe not configured                         |
+|                  | [M-404](/internal/builtins/general/M-404_memory_requests.yaml)           | Medium   | Memory requests not specified                         |
+|                  | [M-405](/internal/builtins/general/M-405_cpu_requests.yaml)              | Medium   | CPU requests not specified                            |
+|                  | [M-406](/internal/builtins/general/M-406_memory_limit.yaml)              | Medium   | Memory not limited                                    |
+|                  | [M-407](/internal/builtins/general/M-407_cpu_limit.yaml)                 | Medium   | CPU not limited                                       |
+|                  | [M-408](/internal/builtins/general/M-408_sudo_container_entrypoint.yaml) | Medium   | Sudo in container entrypoint                          |
+|                  | [M-409](/internal/builtins/general/M-409_deprecated_image_registry.yaml) | Medium   | Deprecated image registry                             |
+| NSA-CISA         | [M-300](/internal/builtins/nsa/M-300_read_only_root_filesystem.yml)      | Low      | Root filesystem write allowed                         |
+| MITRE ATT&CK     | [M-200](/internal/builtins/mitre/M-200_allowed_registries.yml)           | Medium   | Image registry not allowed                            |
 |                  | [M-201](/internal/builtins/mitre/M-201_app_credentials.yml)              | High     | Application credentials stored in configuration files |
-|                  | [M-202](/internal/builtins/mitre/M-202_auto_mount_service_account.yml)  | Low      | Automounted service account token                 |
-|                  | [M-203](/internal/builtins/mitre/M-203_ssh.yml)                          | Low      | SSH server running inside container               |
-| PSS - Baseline   | [M-100](/internal/builtins/pss/baseline/M-100_host_process.yml)         | High     | Privileged access to the Windows node            |
-|                  | [M-101](/internal/builtins/pss/baseline/M-101_host_namespaces.yml)       | High     | Host namespaces                                  |
-|                  | [M-102](/internal/builtins/pss/baseline/M-102_privileged_containers.yml) | High     | Privileged container                             |
-|                  | [M-103](/internal/builtins/pss/baseline/M-103_capabilities.yml)           | High     | Insecure capabilities                            |
-|                  | [M-104](/internal/builtins/pss/baseline/M-104_host_path_volumes.yml)     | High     | HostPath volume                                  |
-|                  | [M-105](/internal/builtins/pss/baseline/M-105_host_ports.yml)            | High     | Not allowed hostPort                             |
-|                  | [M-106](/internal/builtins/pss/baseline/M-106_apparmor.yml)              | Medium   | Forbidden AppArmor profile                       |
-|                  | [M-107](/internal/builtins/pss/baseline/M-107_selinux.yml)               | Medium   | Forbidden SELinux options                        |
-|                  | [M-108](/internal/builtins/pss/baseline/M-108_proc_mount.yml)            | Medium   | Forbidden proc mount type                        |
-|                  | [M-109](/internal/builtins/pss/baseline/M-109_seccomp.yml)               | Medium   | Forbidden seccomp profile                        |
-|                  | [M-110](/internal/builtins/pss/baseline/M-110_sysctls.yml)               | Medium   | Unsafe sysctls                                   |
-| PSS - Restricted | [M-111](/internal/builtins/pss/restricted/M-111_volume_types.yml)        | Low      | Not allowed volume type                          |
-|                  | [M-112](/internal/builtins/pss/restricted/M-112_privilege_escalation.yml)| Medium  | Allowed privilege escalation                     |
-|                  | [M-113](/internal/builtins/pss/restricted/M-113_run_as_non_root.yml)     | Medium   | Container could be running as root user          |
-|                  | [M-114](/internal/builtins/pss/restricted/M-114_run_as_user.yml)         | Low      | Container running as root UID                    |
-|                  | [M-115](/internal/builtins/pss/restricted/M-115_seccomp.yml)             | Low      | Not allowed seccomp profile                      |
-|                  | [M-116](/internal/builtins/pss/restricted/M-116_capabilities.yml)         | Low      | Not allowed added/dropped capabilities           |
+|                  | [M-202](/internal/builtins/mitre/M-202_auto_mount_service_account.yml)   | Low      | Automounted service account token                     |
+|                  | [M-203](/internal/builtins/mitre/M-203_ssh.yml)                          | Low      | SSH server running inside container                   |
+| PSS - Baseline   | [M-100](/internal/builtins/pss/baseline/M-100_host_process.yml)          | High     | Privileged access to the Windows node                 |
+|                  | [M-101](/internal/builtins/pss/baseline/M-101_host_namespaces.yml)       | High     | Host namespaces                                       |
+|                  | [M-102](/internal/builtins/pss/baseline/M-102_privileged_containers.yml) | High     | Privileged container                                  |
+|                  | [M-103](/internal/builtins/pss/baseline/M-103_capabilities.yml)          | High     | Insecure capabilities                                 |
+|                  | [M-104](/internal/builtins/pss/baseline/M-104_host_path_volumes.yml)     | High     | HostPath volume                                       |
+|                  | [M-105](/internal/builtins/pss/baseline/M-105_host_ports.yml)            | High     | Not allowed hostPort                                  |
+|                  | [M-106](/internal/builtins/pss/baseline/M-106_apparmor.yml)              | Medium   | Forbidden AppArmor profile                            |
+|                  | [M-107](/internal/builtins/pss/baseline/M-107_selinux.yml)               | Medium   | Forbidden SELinux options                             |
+|                  | [M-108](/internal/builtins/pss/baseline/M-108_proc_mount.yml)            | Medium   | Forbidden proc mount type                             |
+|                  | [M-109](/internal/builtins/pss/baseline/M-109_seccomp.yml)               | Medium   | Forbidden seccomp profile                             |
+|                  | [M-110](/internal/builtins/pss/baseline/M-110_sysctls.yml)               | Medium   | Unsafe sysctls                                        |
+| PSS - Restricted | [M-111](/internal/builtins/pss/restricted/M-111_volume_types.yml)        | Low      | Not allowed volume type                               |
+|                  | [M-112](/internal/builtins/pss/restricted/M-112_privilege_escalation.yml)| Medium   | Allowed privilege escalation                          |
+|                  | [M-113](/internal/builtins/pss/restricted/M-113_run_as_non_root.yml)     | Medium   | Container could be running as root user               |
+|                  | [M-114](/internal/builtins/pss/restricted/M-114_run_as_user.yml)         | Low      | Container running as root UID                         |
+|                  | [M-115](/internal/builtins/pss/restricted/M-115_seccomp.yml)             | Low      | Not allowed seccomp profile                           |
+|                  | [M-116](/internal/builtins/pss/restricted/M-116_capabilities.yml)        | Low      | Not allowed added/dropped capabilities                |

--- a/checks.md
+++ b/checks.md
@@ -3,7 +3,7 @@
 In the table below, you can view all checks present on Marvin. Click on the #ID column item for more details about each check.
 
 | Framework        | # ID                                                                       | Severity | Message                                          |
-|------------------|---------------------------------------------------------------------------|----------|-----------------------------------------------------|
+|------------------|---------------------------------------------------------------------------|----------|--------------------------------------------------------|
 | CIS Benchmarks   | [M-500](/internal/builtins/cis/M-500_default_namespace.yaml)             | Medium   | Workloads in default namespace                   |
 | General          | [M-400](/internal/builtins/general/M-400_image_tag_latest.yaml)          | Medium   | Image tagged latest                              |
 |                  | [M-401](/internal/builtins/general/M-401_unmanaged_pod.yaml)             | Low      | Unmanaged Pod                                    |

--- a/checks.md
+++ b/checks.md
@@ -3,7 +3,7 @@
 In the table below, you can view all checks present on Marvin. Click on the #ID column item for more details about each check.
 
 | Framework        | # ID                                                                       | Severity | Message                                          |
-|------------------|---------------------------------------------------------------------------|----------|--------------------------------------------------|
+|------------------|---------------------------------------------------------------------------|----------|-----------------------------------------------------|
 | CIS Benchmarks   | [M-500](/internal/builtins/cis/M-500_default_namespace.yaml)             | Medium   | Workloads in default namespace                   |
 | General          | [M-400](/internal/builtins/general/M-400_image_tag_latest.yaml)          | Medium   | Image tagged latest                              |
 |                  | [M-401](/internal/builtins/general/M-401_unmanaged_pod.yaml)             | Low      | Unmanaged Pod                                    |

--- a/checks.md
+++ b/checks.md
@@ -1,0 +1,18 @@
+# Checks Overview  
+
+The table below, we can see all checks present on Marvin.   
+
+| Framework | # ID        | Severity | Message              |
+|-----------|-------------|----------|----------------------|
+| General | [M-400](/internal/builtins/general/M-400_image_tag_latest.yaml) |  Medium  |Image tagged latest| 
+|         | [M-401](/internal/builtins/general/M-401_unmanaged_pod.yaml)| Low | Unmanaged Pod|      
+|         | [M-402](/internal/builtins/general/M-402_readiness_probe.yaml)|Medium |Readiness and startup probe not configured| 
+|         | [M-403](/internal/builtins/general/M-403_liveness_probe.yaml)|  Medium  | Liveness probe not configured|
+|         | [M-404](/internal/builtins/general/M-404_memory_requests.yaml)| Medium  | Memory requests not specified|
+|         | [M-405](/internal/builtins/general/M-405_cpu_requests.yaml)  |  Medium  | CPU requests not specified|
+|         | [M-406](/internal/builtins/general/M-406_memory_limit.yaml)  |  Medium  | Memory not limited|
+|         | [M-407](/internal/builtins/general/M-407_cpu_limit.yaml)     |  Medium  | CPU not limited| 
+| Mitre   |           |          |                      |          
+| NSA     |           |          |                      |           
+| PSS     |           |          |                      |          
+| CIS     |           |          |                      |     

--- a/checks.md
+++ b/checks.md
@@ -4,7 +4,7 @@ In the table below, you can view all checks present on Marvin. Click on the #ID 
 
 | Framework        | # ID                                                                       | Severity | Message                                          |
 |------------------|---------------------------------------------------------------------------|----------|--------------------------------------------------|
-| CIS              | [M-500](/internal/builtins/cis/M-500_default_namespace.yaml)             | Medium   | The default namespace should not be used          |
+| CIS Benchmarks   | [M-500](/internal/builtins/cis/M-500_default_namespace.yaml)             | Medium   | The default namespace should not be used          |
 | General          | [M-400](/internal/builtins/general/M-400_image_tag_latest.yaml)          | Medium   | Image tagged latest                              |
 |                  | [M-401](/internal/builtins/general/M-401_unmanaged_pod.yaml)             | Low      | Unmanaged Pod                                    |
 |                  | [M-402](/internal/builtins/general/M-402_readiness_probe.yaml)           | Medium   | Readiness and startup probe not configured       |

--- a/checks.md
+++ b/checks.md
@@ -1,38 +1,37 @@
 # Checks Overview  
 
-The table below, we can see all checks presents on Marvin.
+In the table below, you can view all checks present on Marvin. Click on the #ID column item for more details about each check.
 
-| Framework | # ID        | Severity | Message              |
-|-----------|:-------------:|:----------:|----------------------|
-| CIS     |[M-500](/internal/builtins/cis/M-500_default_namespace.yaml)|Medium|The default namespace should not be used|
-| General | [M-400](/internal/builtins/general/M-400_image_tag_latest.yaml) |  Medium  |Image tagged latest| 
-|         | [M-401](/internal/builtins/general/M-401_unmanaged_pod.yaml)| Low | Unmanaged Pod|      
-|         | [M-402](/internal/builtins/general/M-402_readiness_probe.yaml)|Medium |Readiness and startup probe not configured| 
-|         | [M-403](/internal/builtins/general/M-403_liveness_probe.yaml)|  Medium  | Liveness probe not configured|
-|         | [M-404](/internal/builtins/general/M-404_memory_requests.yaml)| Medium  | Memory requests not specified|
-|         | [M-405](/internal/builtins/general/M-405_cpu_requests.yaml)  |  Medium  | CPU requests not specified|
-|         | [M-406](/internal/builtins/general/M-406_memory_limit.yaml)  |  Medium  | Memory not limited|
-|         | [M-407](/internal/builtins/general/M-407_cpu_limit.yaml)     |  Medium  | CPU not limited| 
-| NSA     | [M-300](/internal/builtins/nsa/M-300_read_only_root_filesystem.yml)|  Low|   Root filesystem write allowed|   
-| Mitre   | [M-200](/internal/builtins/mitre/M-200_allowed_registries.yml)|Medium|Image registry not allowed| 
-|         |[M-201](/internal/builtins/mitre/M-201_app_credentials.yml)|High|Application credentials stored in configuration files|
-|         |[M-202](/internal/builtins/mitre/M-202_auto_mount_service_account.yml)|Low|Automounted service account token|
-|         |[M-203](/internal/builtins/mitre/M-203_ssh.yml)| Low |SSH server running inside container|
-|         |                                                                    |     |        |
-| PSS - Basline|[M-100](/internal/builtins/pss/baseline/M-100_host_process.yml)|High|Privileged access to the Windows node|
-|         |[M-101](/internal/builtins/pss/baseline/M-101_host_namespaces.yml)|High|Host namespaces|
-|         |[M-102](/internal/builtins/pss/baseline/M-102_privileged_containers.yml)|High|Privileged container|
-|         |[M-103](/internal/builtins/pss/baseline/M-103_capabilities.yml)|High|Insecure capabilities|
-|         |[M-104](/internal/builtins/pss/baseline/M-104_host_path_volumes.yml)|High|HostPath volume|
-|         |[M-105](/internal/builtins/pss/baseline/M-105_host_ports.yml)|High|Not allowed hostPort|
-|         |[M-106](/internal/builtins/pss/baseline/M-106_apparmor.yml)|Medium|Forbidden AppArmor profile|
-|         |[M-107](/internal/builtins/pss/baseline/M-107_selinux.yml)|Medium|Forbidden SELinux options|
-|         |[M-108](/internal/builtins/pss/baseline/M-108_proc_mount.yml)|Medium|Forbidden proc mount type|
-|         |[M-109](/internal/builtins/pss/baseline/M-109_seccomp.yml)|Medium|Forbidden seccomp profile|
-|         |[M-110](/internal/builtins/pss/baseline/M-110_sysctls.yml)|Medium|Unsafe sysctls|
-| PSS - Restricted|[M-111](/internal/builtins/pss/restricted/M-111_volume_types.yml)|Low|Not allowed volume type|
-|      |[M-112](/internal/builtins/pss/restricted/M-112_privilege_escalation.yml)|Medium|Allowed privilege escalation|
-|      |[M-113](/internal/builtins/pss/restricted/M-113_run_as_non_root.yml)|Medium|Container could be running as root user|
-|      |[M-114](/internal/builtins/pss/restricted/M-114_run_as_user.yml)|Low|Container running as root UID|
-|      |[M-115](/internal/builtins/pss/restricted/M-115_seccomp.yml)|Low|Not allowed seccomp profile|
-|      |[M-116](/internal/builtins/pss/restricted/M-116_capabilities.yml)|Low|Not allowed added/dropped capabilities|
+| Framework        | # ID                                                                       | Severity | Message                                          |
+|------------------|---------------------------------------------------------------------------|----------|--------------------------------------------------|
+| CIS              | [M-500](/internal/builtins/cis/M-500_default_namespace.yaml)             | Medium   | The default namespace should not be used          |
+| General          | [M-400](/internal/builtins/general/M-400_image_tag_latest.yaml)          | Medium   | Image tagged latest                              |
+|                  | [M-401](/internal/builtins/general/M-401_unmanaged_pod.yaml)             | Low      | Unmanaged Pod                                    |
+|                  | [M-402](/internal/builtins/general/M-402_readiness_probe.yaml)           | Medium   | Readiness and startup probe not configured       |
+|                  | [M-403](/internal/builtins/general/M-403_liveness_probe.yaml)            | Medium   | Liveness probe not configured                    |
+|                  | [M-404](/internal/builtins/general/M-404_memory_requests.yaml)           | Medium   | Memory requests not specified                    |
+|                  | [M-405](/internal/builtins/general/M-405_cpu_requests.yaml)              | Medium   | CPU requests not specified                       |
+|                  | [M-406](/internal/builtins/general/M-406_memory_limit.yaml)              | Medium   | Memory not limited                               |
+|                  | [M-407](/internal/builtins/general/M-407_cpu_limit.yaml)                 | Medium   | CPU not limited                                  |
+| NSA              | [M-300](/internal/builtins/nsa/M-300_read_only_root_filesystem.yml)     | Low      | Root filesystem write allowed                    |
+| Mitre            | [M-200](/internal/builtins/mitre/M-200_allowed_registries.yml)          | Medium   | Image registry not allowed                       |
+|                  | [M-201](/internal/builtins/mitre/M-201_app_credentials.yml)              | High     | Application credentials stored in configuration files |
+|                  | [M-202](/internal/builtins/mitre/M-202_auto_mount_service_account.yml)  | Low      | Automounted service account token                 |
+|                  | [M-203](/internal/builtins/mitre/M-203_ssh.yml)                          | Low      | SSH server running inside container               |
+| PSS - Baseline   | [M-100](/internal/builtins/pss/baseline/M-100_host_process.yml)         | High     | Privileged access to the Windows node            |
+|                  | [M-101](/internal/builtins/pss/baseline/M-101_host_namespaces.yml)       | High     | Host namespaces                                  |
+|                  | [M-102](/internal/builtins/pss/baseline/M-102_privileged_containers.yml) | High     | Privileged container                             |
+|                  | [M-103](/internal/builtins/pss/baseline/M-103_capabilities.yml)           | High     | Insecure capabilities                            |
+|                  | [M-104](/internal/builtins/pss/baseline/M-104_host_path_volumes.yml)     | High     | HostPath volume                                  |
+|                  | [M-105](/internal/builtins/pss/baseline/M-105_host_ports.yml)            | High     | Not allowed hostPort                             |
+|                  | [M-106](/internal/builtins/pss/baseline/M-106_apparmor.yml)              | Medium   | Forbidden AppArmor profile                       |
+|                  | [M-107](/internal/builtins/pss/baseline/M-107_selinux.yml)               | Medium   | Forbidden SELinux options                        |
+|                  | [M-108](/internal/builtins/pss/baseline/M-108_proc_mount.yml)            | Medium   | Forbidden proc mount type                        |
+|                  | [M-109](/internal/builtins/pss/baseline/M-109_seccomp.yml)               | Medium   | Forbidden seccomp profile                        |
+|                  | [M-110](/internal/builtins/pss/baseline/M-110_sysctls.yml)               | Medium   | Unsafe sysctls                                   |
+| PSS - Restricted | [M-111](/internal/builtins/pss/restricted/M-111_volume_types.yml)        | Low      | Not allowed volume type                          |
+|                  | [M-112](/internal/builtins/pss/restricted/M-112_privilege_escalation.yml)| Medium  | Allowed privilege escalation                     |
+|                  | [M-113](/internal/builtins/pss/restricted/M-113_run_as_non_root.yml)     | Medium   | Container could be running as root user          |
+|                  | [M-114](/internal/builtins/pss/restricted/M-114_run_as_user.yml)         | Low      | Container running as root UID                    |
+|                  | [M-115](/internal/builtins/pss/restricted/M-115_seccomp.yml)             | Low      | Not allowed seccomp profile                      |
+|                  | [M-116](/internal/builtins/pss/restricted/M-116_capabilities.yml)         | Low      | Not allowed added/dropped capabilities           |

--- a/checks.md
+++ b/checks.md
@@ -14,7 +14,7 @@ In the table below, you can view all checks present on Marvin. Click on the #ID 
 |                  | [M-406](/internal/builtins/general/M-406_memory_limit.yaml)              | Medium   | Memory not limited                               |
 |                  | [M-407](/internal/builtins/general/M-407_cpu_limit.yaml)                 | Medium   | CPU not limited                                  |
 | NSA              | [M-300](/internal/builtins/nsa/M-300_read_only_root_filesystem.yml)     | Low      | Root filesystem write allowed                    |
-| Mitre            | [M-200](/internal/builtins/mitre/M-200_allowed_registries.yml)          | Medium   | Image registry not allowed                       |
+| MITRE ATT&CK     | [M-200](/internal/builtins/mitre/M-200_allowed_registries.yml)          | Medium   | Image registry not allowed                       |
 |                  | [M-201](/internal/builtins/mitre/M-201_app_credentials.yml)              | High     | Application credentials stored in configuration files |
 |                  | [M-202](/internal/builtins/mitre/M-202_auto_mount_service_account.yml)  | Low      | Automounted service account token                 |
 |                  | [M-203](/internal/builtins/mitre/M-203_ssh.yml)                          | Low      | SSH server running inside container               |

--- a/checks.md
+++ b/checks.md
@@ -13,7 +13,7 @@ In the table below, you can view all checks present on Marvin. Click on the #ID 
 |                  | [M-405](/internal/builtins/general/M-405_cpu_requests.yaml)              | Medium   | CPU requests not specified                       |
 |                  | [M-406](/internal/builtins/general/M-406_memory_limit.yaml)              | Medium   | Memory not limited                               |
 |                  | [M-407](/internal/builtins/general/M-407_cpu_limit.yaml)                 | Medium   | CPU not limited                                  |
-| NSA              | [M-300](/internal/builtins/nsa/M-300_read_only_root_filesystem.yml)     | Low      | Root filesystem write allowed                    |
+| NSA-CISA         | [M-300](/internal/builtins/nsa/M-300_read_only_root_filesystem.yml)     | Low      | Root filesystem write allowed                    |
 | MITRE ATT&CK     | [M-200](/internal/builtins/mitre/M-200_allowed_registries.yml)          | Medium   | Image registry not allowed                       |
 |                  | [M-201](/internal/builtins/mitre/M-201_app_credentials.yml)              | High     | Application credentials stored in configuration files |
 |                  | [M-202](/internal/builtins/mitre/M-202_auto_mount_service_account.yml)  | Low      | Automounted service account token                 |

--- a/checks.md
+++ b/checks.md
@@ -3,7 +3,7 @@
 The table below, we can see all checks present on Marvin.   
 
 | Framework | # ID        | Severity | Message              |
-|-----------|-------------|----------|----------------------|
+|-----------|:-------------:|:----------:|----------------------|
 | General | [M-400](/internal/builtins/general/M-400_image_tag_latest.yaml) |  Medium  |Image tagged latest| 
 |         | [M-401](/internal/builtins/general/M-401_unmanaged_pod.yaml)| Low | Unmanaged Pod|      
 |         | [M-402](/internal/builtins/general/M-402_readiness_probe.yaml)|Medium |Readiness and startup probe not configured| 
@@ -12,7 +12,21 @@ The table below, we can see all checks present on Marvin.
 |         | [M-405](/internal/builtins/general/M-405_cpu_requests.yaml)  |  Medium  | CPU requests not specified|
 |         | [M-406](/internal/builtins/general/M-406_memory_limit.yaml)  |  Medium  | Memory not limited|
 |         | [M-407](/internal/builtins/general/M-407_cpu_limit.yaml)     |  Medium  | CPU not limited| 
-| Mitre   |           |          |                      |          
-| NSA     |           |          |                      |           
-| PSS     |           |          |                      |          
-| CIS     |           |          |                      |     
+| NSA     | [M-300](/internal/builtins/nsa/M-300_read_only_root_filesystem.yml)|  Low|   Root filesystem write allowed|   
+| Mitre   | [M-200](/internal/builtins/mitre/M-200_allowed_registries.yml)|Medium|Image registry not allowed| 
+|         |[M-201](/internal/builtins/mitre/M-201_app_credentials.yml)|High|Application credentials stored in configuration files|
+|         |[M-202](/internal/builtins/mitre/M-202_auto_mount_service_account.yml)|Low|Automounted service account token|
+|         |[M-203](/internal/builtins/mitre/M-203_ssh.yml)| Low |SSH server running inside container|
+|         |                                                                    |     |        |
+| PSS - Basline|[M100](/internal/builtins/pss/baseline/M-100_host_process.yml)|High|Privileged access to the Windows node|
+|         |[M101](/internal/builtins/pss/baseline/M-101_host_namespaces.yml)|High|Host namespaces|
+|         |[M102](/internal/builtins/pss/baseline/M-102_privileged_containers.yml)|High|Privileged container|
+|         |[M103](/internal/builtins/pss/baseline/M-103_capabilities.yml)|High|Insecure capabilities|
+|         |[M104](/internal/builtins/pss/baseline/M-104_host_path_volumes.yml)|High|HostPath volume|
+|         |[M105](/internal/builtins/pss/baseline/M-105_host_ports.yml)|High|Not allowed hostPort|
+|         |[M106](/internal/builtins/pss/baseline/M-106_apparmor.yml)|Medium|Forbidden AppArmor profile|
+|         |[M107](/internal/builtins/pss/baseline/M-107_selinux.yml)|Medium|Forbidden SELinux options|
+|         |[M108](/internal/builtins/pss/baseline/M-108_proc_mount.yml)|Medium|Forbidden proc mount type|
+|         |[M109](/internal/builtins/pss/baseline/M-109_seccomp.yml)|Medium|Forbidden seccomp profile|
+|         |[M110](/internal/builtins/pss/baseline/M-110_sysctls.yml)|Medium|Unsafe sysctls|
+| CIS     |           |          |                      | | 

--- a/internal/builtins/cis/M-500_default_namespace.yaml
+++ b/internal/builtins/cis/M-500_default_namespace.yaml
@@ -15,7 +15,7 @@
 
 id: M-500
 severity: Medium
-message: "The default namespace should not be used"
+message: "Workloads in default namespace"
 match:
   resources:
     - group: ""

--- a/internal/builtins/cis/M-500_default_namespace.yaml
+++ b/internal/builtins/cis/M-500_default_namespace.yaml
@@ -1,0 +1,29 @@
+# Copyright 2023 Undistro Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+id: M-500
+severity: Medium
+message: "Required namespace"
+match:
+  resources:
+    - group: apps
+      version: v1
+      resource: deployments
+validations:
+  - expression: >
+     has(object.metadata.namespace)
+     && (type(object.metadata.namespace) == string)
+     && !(object.metadata.namespace == 'default')	
+    message: "Namespace not found"

--- a/internal/builtins/cis/M-500_default_namespace.yaml
+++ b/internal/builtins/cis/M-500_default_namespace.yaml
@@ -18,7 +18,6 @@ severity: Medium
 message: "The default namespace should not be used"
 match:
   resources:
-    resources:
     - group: ""
       version: v1
       resource: pods

--- a/internal/builtins/cis/M-500_default_namespace.yaml
+++ b/internal/builtins/cis/M-500_default_namespace.yaml
@@ -15,15 +15,33 @@
 
 id: M-500
 severity: Medium
-message: "Required namespace"
+message: "The default namespace should not be used"
 match:
   resources:
+    resources:
+    - group: ""
+      version: v1
+      resource: pods
     - group: apps
       version: v1
       resource: deployments
+    - group: apps
+      version: v1
+      resource: daemonsets
+    - group: apps
+      version: v1
+      resource: statefulsets
+    - group: apps
+      version: v1
+      resource: replicasets
+    - group: batch
+      version: v1
+      resource: cronjobs
+    - group: batch
+      version: v1
+      resource: jobs
 validations:
   - expression: >
      has(object.metadata.namespace)
      && (type(object.metadata.namespace) == string)
-     && !(object.metadata.namespace == 'default')	
-    message: "Namespace not found"
+     && !(object.metadata.namespace == 'default')

--- a/internal/builtins/cis/M-500_default_namespace_test.yaml
+++ b/internal/builtins/cis/M-500_default_namespace_test.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: "Namespace specified like default"
+- name: "Namespace set to default"
   pass: false
   input: |
     apiVersion: apps/v1

--- a/internal/builtins/cis/M-500_default_namespace_test.yaml
+++ b/internal/builtins/cis/M-500_default_namespace_test.yaml
@@ -1,0 +1,81 @@
+# Copyright 2023 Undistro Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: "Namespace specified like default"
+  pass: false
+  input: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: nginx
+      namespace: default
+    spec:
+      template:
+        metadata:
+          name: nginx
+          labels:
+            app: nginx
+        spec:
+          containers:
+            - name: nginx
+              image: nginx
+      selector:
+        matchLabels:
+          app: nginx
+
+- name: "Namespace not specified"
+  pass: false
+  input: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: nginx
+    spec:
+      template:
+        metadata:
+          name: nginx
+          labels:
+            app: nginx
+        spec:
+          volumes: []
+          containers:
+            - name: nginx
+              image: nginx
+      selector:
+        matchLabels:
+          app: nginx
+
+
+- name: "Namespace specified"
+  pass: true
+  input: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: nginx
+      namespace: fooserver
+    spec:
+      template:
+        metadata:
+          name: nginx
+          labels:
+            app: nginx
+        spec:
+          volumes: []
+          containers:
+            - name: nginx
+              image: nginx
+      selector:
+        matchLabels:
+          app: nginx

--- a/internal/builtins/cis/M-500_default_namespace_test.yaml
+++ b/internal/builtins/cis/M-500_default_namespace_test.yaml
@@ -56,7 +56,6 @@
         matchLabels:
           app: nginx
 
-
 - name: "Namespace specified"
   pass: true
   input: |

--- a/internal/builtins/general/M-408_sudo_container_entrypoint.yaml
+++ b/internal/builtins/general/M-408_sudo_container_entrypoint.yaml
@@ -1,0 +1,49 @@
+# Copyright 2023 Undistro Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: M-408
+slug: sudo-container-entrypoint
+severity: Medium
+message: "Sudo in container entrypoint"
+match:
+  resources:
+    - group: ""
+      version: v1
+      resource: pods
+    - group: apps
+      version: v1
+      resource: deployments
+    - group: apps
+      version: v1
+      resource: daemonsets
+    - group: apps
+      version: v1
+      resource: statefulsets
+    - group: apps
+      version: v1
+      resource: replicasets
+    - group: batch
+      version: v1
+      resource: cronjobs
+    - group: batch
+      version: v1
+      resource: jobs
+validations:
+  - expression: >
+      allContainers.all(container, 
+      !has(container.command) ||
+      size(container.command) == 0 ||
+      container.command.all(cmd,
+      !cmd.contains("sudo"))
+      )

--- a/internal/builtins/general/M-408_sudo_container_entrypoint_test.yaml
+++ b/internal/builtins/general/M-408_sudo_container_entrypoint_test.yaml
@@ -1,0 +1,64 @@
+# Copyright 2023 Undistro Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: "command not set"
+  pass: true
+  input: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx
+
+- name: "command without sudo"
+  pass: true
+  input: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx
+          command: ["printenv"]
+          resources:
+            requests:
+              cpu: 5m
+
+
+- name: "command with sudo on entrypoint"
+  pass: false
+  input: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx
+          command: ["sudo printenv"]
+          resources:
+            limits:
+              memory: 128Mi

--- a/internal/builtins/general/M-409_deprecated_image_registry.yaml
+++ b/internal/builtins/general/M-409_deprecated_image_registry.yaml
@@ -1,0 +1,46 @@
+# Copyright 2023 Undistro Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: M-409
+slug: depŕecated image registry
+severity: Medium
+message: "Deprecated image registry"
+match:
+  resources:
+    - group: ""
+      version: v1
+      resource: pods
+    - group: apps
+      version: v1
+      resource: deployments
+    - group: apps
+      version: v1
+      resource: daemonsets
+    - group: apps
+      version: v1
+      resource: statefulsets
+    - group: apps
+      version: v1
+      resource: replicasets
+    - group: batch
+      version: v1
+      resource: cronjobs
+    - group: batch
+      version: v1
+      resource: jobs
+validations:
+  - expression: >
+      allContainers.all(container,
+      !container.image.contains("k8s.grc.io"))
+

--- a/internal/builtins/general/M-409_deprecated_image_registry_test.yaml
+++ b/internal/builtins/general/M-409_deprecated_image_registry_test.yaml
@@ -1,0 +1,85 @@
+# Copyright 2023 Undistro Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: "registry not defined"
+  pass: true
+  input: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx
+
+
+
+- name: "registry deprecated"
+  pass: false
+  input: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: registry
+          image: registry.com:80/nginx@sha256:asdf
+        - name: ok2
+          image: registry.com:80/nginx@sha256:asdf
+        - name: wrong
+          image: k8s.grc.io/pause
+
+- name: "registry deprecated middle"
+  pass: false
+  input: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: registry
+          image: registry.com:80/nginx@sha256:asdf
+        - name: wrong
+          image: k8s.grc.io/pause
+        - name: ok2
+          image: registry.com:80/nginx@sha256:asdf
+
+
+
+- name: "registry deprecated"
+  pass: false
+  input: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: registry
+          image: registry.com:80/nginx@sha256:asdf
+        - name:  registryOK
+          image: registry.com:80/nginx@sha256:asdf
+        - name: wrong
+          image: k8s.grc.io/pause

--- a/pkg/loader/builtin_test.go
+++ b/pkg/loader/builtin_test.go
@@ -23,5 +23,5 @@ import (
 func TestBuiltins(t *testing.T) {
 	assert.NotNil(t, Builtins)
 	assert.Greater(t, len(Builtins), 0)
-	assert.Equal(t, len(Builtins), 30)
+	assert.Equal(t, len(Builtins), 31)
 }

--- a/pkg/loader/builtin_test.go
+++ b/pkg/loader/builtin_test.go
@@ -23,5 +23,5 @@ import (
 func TestBuiltins(t *testing.T) {
 	assert.NotNil(t, Builtins)
 	assert.Greater(t, len(Builtins), 0)
-	assert.Equal(t, len(Builtins), 31)
+	assert.Equal(t, len(Builtins), 33)
 }


### PR DESCRIPTION
## Description
Created checks for:

- sudo in container entrypoint;
- image with registry deprecated .

Both was added in general session.

## How has this been tested?
- run `make test` for unit test
- 1)create a deployment and 2) run checks with marvin: `marvin scan --disable-builtin --checks ./internal/builtins/general/M-408_sudo_container_entrypoint.yaml` check the results and 3) run `marvin scan --disable-builtin --checks ./internal/builtins/general/M-409_deprecated_image_registry.yaml.` 

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [x] My changes are covered by tests
