### PR TITLE
check for restartPolicy

### DIFF
--- a/checks.md
+++ b/checks.md
@@ -16,6 +16,7 @@ In the table below, you can view all checks present on Marvin. Click on the #ID 
 |                  | [M-407](/internal/builtins/general/M-407_cpu_limit.yaml)                 | Medium   | CPU not limited                                       |
 |                  | [M-408](/internal/builtins/general/M-408_sudo_container_entrypoint.yaml) | Medium   | Sudo in container entrypoint                          |
 |                  | [M-409](/internal/builtins/general/M-409_deprecated_image_registry.yaml) | Medium   | Deprecated image registry                             |
+|                  | [M-410](/internal/builtins/general/M-410_resource_using_invalid_restartpolicy.yaml) | Medium| Resource is using an invalid restartPolicy    |
 | NSA-CISA         | [M-300](/internal/builtins/nsa/M-300_read_only_root_filesystem.yml)      | Low      | Root filesystem write allowed                         |
 | MITRE ATT&CK     | [M-200](/internal/builtins/mitre/M-200_allowed_registries.yml)           | Medium   | Image registry not allowed                            |
 |                  | [M-201](/internal/builtins/mitre/M-201_app_credentials.yml)              | High     | Application credentials stored in configuration files |

--- a/internal/builtins/general/M-410_resource_using_invalid_restartpolicy.yaml
+++ b/internal/builtins/general/M-410_resource_using_invalid_restartpolicy.yaml
@@ -1,0 +1,34 @@
+# Copyright 2023 Undistro Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: M-410
+slug: resource using invalid restartPolicy
+severity: Medium
+message: "Resource is using an invalid restartPolicy"
+match:
+  resources:
+    - group: apps
+      version: v1
+      resource: deployments
+    - group: apps
+      version: v1
+      resource: daemonsets
+    - group: apps
+      version: v1
+      resource: replicasets
+validations:
+  - expression: >
+      !has(podSpec.restartPolicy) ||
+      has(podSpec.restartPolicy) &&
+      (podSpec.restartPolicy =='Always')

--- a/internal/builtins/general/M-410_resource_using_invalid_restartpolicy_test.yaml
+++ b/internal/builtins/general/M-410_resource_using_invalid_restartpolicy_test.yaml
@@ -1,0 +1,103 @@
+# Copyright 2023 Undistro Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: "restartPolicy set Onfailure"
+  pass: false
+  input: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: nginx
+    spec:
+      template:
+        metadata:
+          name: nginx
+          labels:
+            app: nginx
+        spec:
+          containers:
+            - name: nginx
+              image: nginx
+          restartPolicy: OnFailure
+      selector:
+        matchLabels:
+          app: nginx     
+
+
+
+- name: "restartPolicy set Always"
+  pass: true
+  input: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: nginx
+    spec:
+      template:
+        metadata:
+          name: nginx
+          labels:
+            app: nginx
+        spec:
+          containers:
+            - name: nginx
+              image: nginx
+          restartPolicy: Always
+      selector:
+        matchLabels:
+          app: nginx   
+
+
+- name: "restartPolicy not defined"
+  pass: true
+  input: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: nginx
+    spec:
+      template:
+        metadata:
+          name: nginx
+          labels:
+            app: nginx
+        spec:
+          containers:
+            - name: nginx
+              image: nginx
+      selector:
+        matchLabels:
+          app: nginx
+
+- name: "restartPolicy set Never"
+  pass: false
+  input: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: nginx
+    spec:
+      template:
+        metadata:
+          name: nginx
+          labels:
+            app: nginx
+        spec:
+          containers:
+            - name: nginx
+              image: nginx
+          restartPolicy: Never
+      selector:
+        matchLabels:
+          app: nginx

--- a/pkg/loader/builtin_test.go
+++ b/pkg/loader/builtin_test.go
@@ -23,5 +23,5 @@ import (
 func TestBuiltins(t *testing.T) {
 	assert.NotNil(t, Builtins)
 	assert.Greater(t, len(Builtins), 0)
-	assert.Equal(t, len(Builtins), 33)
+	assert.Equal(t, len(Builtins), 34)
 }


### PR DESCRIPTION
## Description
Hello!

I added a new check for restartPolicy in objects like: deployment, daemonset and replicaset. For them, the value from restartPolicy always should be "Always"  

## How has this been tested?
- Check with [CEL Playground](https://playcel.undistro.io/?content=H4sIAAAAAAAAA41RsU4DMQz9FZOhpRK9A7GgSB2QGBm6wEIYzJ11jUicKAmlFeXfSdoepCzgTLHf83u2P0SPCYUU6PUjhagdS0DvY7u%2BUvyquZdwR964rSVOii0lLAypGIDRkgQeNG%2FmfQUCMPhCJu5BUNodUYqjp26fDhmvO4wSrss3kqEuuXCkWEzd6r5uctoGIJH1BhONhNpXCXNK%2Fk3PiqOTEp3jhJrzAirGvB7wJw2gLQ45n2JqhtA12rUe3yJBjemctVi296SED5oT8VqJ5xriXUi1XlH8NrLMRQk3l2M5UEwY0tLlrW0l3Jp33EZxIWjjc6ncLR%2BxbeEhah4AYY1G9yMrSxWa4sM7W2E8L%2FM34xab%2Fe9EYwa7neL%2FIScTxX%2FCYLGYHmxPZ%2BLzC7EP5X55AgAA);
- Run `make test` on your host;
- List any relevant details for your test configuration.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [x] My changes are covered by tests
