### PR TITLE
Bump alpine base image to 3.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
     -X github.com/undistro/marvin/pkg/version.commit=${COMMIT} \
     -X github.com/undistro/marvin/pkg/version.date=${DATE}" -a -o marvin main.go
 
-FROM alpine:3.19.0
+FROM alpine:3.19.1
 
 RUN addgroup -g 8494 -S nonroot && adduser -u 8494 -D -S nonroot -G nonroot
 USER 8494:8494


### PR DESCRIPTION
## Description
Bump alpine base image to 3.19.1

Before:
```
trivy image ghcr.io/undistro/marvin:v0.2.1
2024-02-14T11:48:57.483-0300	INFO	Vulnerability scanning is enabled
2024-02-14T11:48:57.483-0300	INFO	Secret scanning is enabled
2024-02-14T11:48:57.483-0300	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-02-14T11:48:57.483-0300	INFO	Please see also https://aquasecurity.github.io/trivy/v0.48/docs/scanner/secret/#recommendation for faster secret detection
2024-02-14T11:48:58.664-0300	INFO	Detected OS: alpine
2024-02-14T11:48:58.664-0300	WARN	This OS version is not on the EOL list: alpine 3.19
2024-02-14T11:48:58.664-0300	INFO	Detecting Alpine vulnerabilities...
2024-02-14T11:48:58.669-0300	INFO	Number of language-specific files: 1
2024-02-14T11:48:58.669-0300	INFO	Detecting gobinary vulnerabilities...

ghcr.io/undistro/marvin:v0.2.1 (alpine 3.19.0)

Total: 6 (UNKNOWN: 0, LOW: 0, MEDIUM: 6, HIGH: 0, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                           │
├────────────┼───────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-6129 │ MEDIUM   │ fixed  │ 3.1.4-r2          │ 3.1.4-r3      │ openssl: POLY1305 MAC implementation corrupts vector      │
│            │               │          │        │                   │               │ registers on PowerPC                                      │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6129                 │
│            ├───────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│            │ CVE-2023-6237 │          │        │                   │ 3.1.4-r4      │ openssl: Excessive time spent checking invalid RSA public │
│            │               │          │        │                   │               │ keys                                                      │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6237                 │
│            ├───────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│            │ CVE-2024-0727 │          │        │                   │ 3.1.4-r5      │ openssl: denial of service via null dereference           │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-0727                 │
├────────────┼───────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│ libssl3    │ CVE-2023-6129 │          │        │                   │ 3.1.4-r3      │ openssl: POLY1305 MAC implementation corrupts vector      │
│            │               │          │        │                   │               │ registers on PowerPC                                      │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6129                 │
│            ├───────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│            │ CVE-2023-6237 │          │        │                   │ 3.1.4-r4      │ openssl: Excessive time spent checking invalid RSA public │
│            │               │          │        │                   │               │ keys                                                      │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6237                 │
│            ├───────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│            │ CVE-2024-0727 │          │        │                   │ 3.1.4-r5      │ openssl: denial of service via null dereference           │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-0727                 │
└────────────┴───────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘
```

Now: 
```
trivy image ghcr.io/undistro/marvin:latest
2024-02-14T11:51:49.760-0300	INFO	Vulnerability scanning is enabled
2024-02-14T11:51:49.760-0300	INFO	Secret scanning is enabled
2024-02-14T11:51:49.760-0300	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-02-14T11:51:49.760-0300	INFO	Please see also https://aquasecurity.github.io/trivy/v0.48/docs/scanner/secret/#recommendation for faster secret detection
2024-02-14T11:51:50.583-0300	INFO	Detected OS: alpine
2024-02-14T11:51:50.583-0300	WARN	This OS version is not on the EOL list: alpine 3.19
2024-02-14T11:51:50.583-0300	INFO	Detecting Alpine vulnerabilities...
2024-02-14T11:51:50.594-0300	INFO	Number of language-specific files: 1
2024-02-14T11:51:50.595-0300	INFO	Detecting gobinary vulnerabilities...

ghcr.io/undistro/marvin:latest (alpine 3.19.1)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
