### PR TITLE
Check non-zero runAsUser in M-113

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Medium     M-108   Forbidden proc mount type                               Passe
 Medium     M-109   Forbidden seccomp profile                               Passed   0        33       0         
 Medium     M-110   Unsafe sysctls                                          Passed   0        33       0         
 Medium     M-112   Allowed privilege escalation                            Passed   0        33       0         
+Medium     M-114   Container running as root UID                           Passed   0        33       0         
 Medium     M-200   Image registry not allowed                              Passed   0        33       0         
 Medium     M-400   Image tagged latest                                     Passed   0        33       0         
 Medium     M-408   Sudo in container entrypoint                            Passed   0        33       0         
@@ -122,7 +123,6 @@ Low        M-115   Not allowed seccomp profile                             Faile
 Low        M-300   Root filesystem write allowed                           Failed   29       4        0         
 Low        M-111   Not allowed volume type                                 Failed   8        25       0         
 Low        M-203   SSH server running inside container                     Passed   0        39       0         
-Low        M-114   Container running as root UID                           Passed   0        33       0         
 Low        M-401   Unmanaged Pod                                           Passed   0        15       0         
 ```
 

--- a/checks.md
+++ b/checks.md
@@ -3,39 +3,39 @@
 In the table below, you can view all checks present on Marvin. Click on the #ID column item for more details about each check.
 
 
-| Framework        | #ID                                                                      | Severity  | Message                                              |
-|------------------|--------------------------------------------------------------------------|---------- |------------------------------------------------------|
-| CIS Benchmarks   | [M-500](/internal/builtins/cis/M-500_default_namespace.yaml)             | Medium   | Workloads in default namespace                        |
-| General          | [M-400](/internal/builtins/general/M-400_image_tag_latest.yaml)          | Medium   | Image tagged latest                                   |
-|                  | [M-401](/internal/builtins/general/M-401_unmanaged_pod.yaml)             | Low      | Unmanaged Pod                                         |
-|                  | [M-402](/internal/builtins/general/M-402_readiness_probe.yaml)           | Medium   | Readiness and startup probe not configured            |
-|                  | [M-403](/internal/builtins/general/M-403_liveness_probe.yaml)            | Medium   | Liveness probe not configured                         |
-|                  | [M-404](/internal/builtins/general/M-404_memory_requests.yaml)           | Medium   | Memory requests not specified                         |
-|                  | [M-405](/internal/builtins/general/M-405_cpu_requests.yaml)              | Medium   | CPU requests not specified                            |
-|                  | [M-406](/internal/builtins/general/M-406_memory_limit.yaml)              | Medium   | Memory not limited                                    |
-|                  | [M-407](/internal/builtins/general/M-407_cpu_limit.yaml)                 | Medium   | CPU not limited                                       |
-|                  | [M-408](/internal/builtins/general/M-408_sudo_container_entrypoint.yaml) | Medium   | Sudo in container entrypoint                          |
-|                  | [M-409](/internal/builtins/general/M-409_deprecated_image_registry.yaml) | Medium   | Deprecated image registry                             |
-|                  | [M-410](/internal/builtins/general/M-410_resource_using_invalid_restartpolicy.yaml) | Medium| Resource is using an invalid restartPolicy    |
-| NSA-CISA         | [M-300](/internal/builtins/nsa/M-300_read_only_root_filesystem.yml)      | Low      | Root filesystem write allowed                         |
-| MITRE ATT&CK     | [M-200](/internal/builtins/mitre/M-200_allowed_registries.yml)           | Medium   | Image registry not allowed                            |
-|                  | [M-201](/internal/builtins/mitre/M-201_app_credentials.yml)              | High     | Application credentials stored in configuration files |
-|                  | [M-202](/internal/builtins/mitre/M-202_auto_mount_service_account.yml)   | Low      | Automounted service account token                     |
-|                  | [M-203](/internal/builtins/mitre/M-203_ssh.yml)                          | Low      | SSH server running inside container                   |
-| PSS - Baseline   | [M-100](/internal/builtins/pss/baseline/M-100_host_process.yml)          | High     | Privileged access to the Windows node                 |
-|                  | [M-101](/internal/builtins/pss/baseline/M-101_host_namespaces.yml)       | High     | Host namespaces                                       |
-|                  | [M-102](/internal/builtins/pss/baseline/M-102_privileged_containers.yml) | High     | Privileged container                                  |
-|                  | [M-103](/internal/builtins/pss/baseline/M-103_capabilities.yml)          | High     | Insecure capabilities                                 |
-|                  | [M-104](/internal/builtins/pss/baseline/M-104_host_path_volumes.yml)     | High     | HostPath volume                                       |
-|                  | [M-105](/internal/builtins/pss/baseline/M-105_host_ports.yml)            | High     | Not allowed hostPort                                  |
-|                  | [M-106](/internal/builtins/pss/baseline/M-106_apparmor.yml)              | Medium   | Forbidden AppArmor profile                            |
-|                  | [M-107](/internal/builtins/pss/baseline/M-107_selinux.yml)               | Medium   | Forbidden SELinux options                             |
-|                  | [M-108](/internal/builtins/pss/baseline/M-108_proc_mount.yml)            | Medium   | Forbidden proc mount type                             |
-|                  | [M-109](/internal/builtins/pss/baseline/M-109_seccomp.yml)               | Medium   | Forbidden seccomp profile                             |
-|                  | [M-110](/internal/builtins/pss/baseline/M-110_sysctls.yml)               | Medium   | Unsafe sysctls                                        |
-| PSS - Restricted | [M-111](/internal/builtins/pss/restricted/M-111_volume_types.yml)        | Low      | Not allowed volume type                               |
-|                  | [M-112](/internal/builtins/pss/restricted/M-112_privilege_escalation.yml)| Medium   | Allowed privilege escalation                          |
-|                  | [M-113](/internal/builtins/pss/restricted/M-113_run_as_non_root.yml)     | Medium   | Container could be running as root user               |
-|                  | [M-114](/internal/builtins/pss/restricted/M-114_run_as_user.yml)         | Medium   | Container running as root UID                         |
-|                  | [M-115](/internal/builtins/pss/restricted/M-115_seccomp.yml)             | Low      | Not allowed seccomp profile                           |
-|                  | [M-116](/internal/builtins/pss/restricted/M-116_capabilities.yml)        | Low      | Not allowed added/dropped capabilities                |
+| Framework        | #ID                                                                                 | Severity | Message                                               |
+|------------------|-------------------------------------------------------------------------------------|----------|-------------------------------------------------------|
+| CIS Benchmarks   | [M-500](/internal/builtins/cis/M-500_default_namespace.yaml)                        | Medium   | Workloads in default namespace                        |
+| General          | [M-400](/internal/builtins/general/M-400_image_tag_latest.yaml)                     | Medium   | Image tagged latest                                   |
+|                  | [M-401](/internal/builtins/general/M-401_unmanaged_pod.yaml)                        | Low      | Unmanaged Pod                                         |
+|                  | [M-402](/internal/builtins/general/M-402_readiness_probe.yaml)                      | Medium   | Readiness and startup probe not configured            |
+|                  | [M-403](/internal/builtins/general/M-403_liveness_probe.yaml)                       | Medium   | Liveness probe not configured                         |
+|                  | [M-404](/internal/builtins/general/M-404_memory_requests.yaml)                      | Medium   | Memory requests not specified                         |
+|                  | [M-405](/internal/builtins/general/M-405_cpu_requests.yaml)                         | Medium   | CPU requests not specified                            |
+|                  | [M-406](/internal/builtins/general/M-406_memory_limit.yaml)                         | Medium   | Memory not limited                                    |
+|                  | [M-407](/internal/builtins/general/M-407_cpu_limit.yaml)                            | Medium   | CPU not limited                                       |
+|                  | [M-408](/internal/builtins/general/M-408_sudo_container_entrypoint.yaml)            | Medium   | Sudo in container entrypoint                          |
+|                  | [M-409](/internal/builtins/general/M-409_deprecated_image_registry.yaml)            | Medium   | Deprecated image registry                             |
+|                  | [M-410](/internal/builtins/general/M-410_resource_using_invalid_restartpolicy.yaml) | Medium   | Resource is using an invalid restartPolicy            |
+| NSA-CISA         | [M-300](/internal/builtins/nsa/M-300_read_only_root_filesystem.yml)                 | Low      | Root filesystem write allowed                         |
+| MITRE ATT&CK     | [M-200](/internal/builtins/mitre/M-200_allowed_registries.yml)                      | Medium   | Image registry not allowed                            |
+|                  | [M-201](/internal/builtins/mitre/M-201_app_credentials.yml)                         | High     | Application credentials stored in configuration files |
+|                  | [M-202](/internal/builtins/mitre/M-202_auto_mount_service_account.yml)              | Low      | Automounted service account token                     |
+|                  | [M-203](/internal/builtins/mitre/M-203_ssh.yml)                                     | Low      | SSH server running inside container                   |
+| PSS - Baseline   | [M-100](/internal/builtins/pss/baseline/M-100_host_process.yml)                     | High     | Privileged access to the Windows node                 |
+|                  | [M-101](/internal/builtins/pss/baseline/M-101_host_namespaces.yml)                  | High     | Host namespaces                                       |
+|                  | [M-102](/internal/builtins/pss/baseline/M-102_privileged_containers.yml)            | High     | Privileged container                                  |
+|                  | [M-103](/internal/builtins/pss/baseline/M-103_capabilities.yml)                     | High     | Insecure capabilities                                 |
+|                  | [M-104](/internal/builtins/pss/baseline/M-104_host_path_volumes.yml)                | High     | HostPath volume                                       |
+|                  | [M-105](/internal/builtins/pss/baseline/M-105_host_ports.yml)                       | High     | Not allowed hostPort                                  |
+|                  | [M-106](/internal/builtins/pss/baseline/M-106_apparmor.yml)                         | Medium   | Forbidden AppArmor profile                            |
+|                  | [M-107](/internal/builtins/pss/baseline/M-107_selinux.yml)                          | Medium   | Forbidden SELinux options                             |
+|                  | [M-108](/internal/builtins/pss/baseline/M-108_proc_mount.yml)                       | Medium   | Forbidden proc mount type                             |
+|                  | [M-109](/internal/builtins/pss/baseline/M-109_seccomp.yml)                          | Medium   | Forbidden seccomp profile                             |
+|                  | [M-110](/internal/builtins/pss/baseline/M-110_sysctls.yml)                          | Medium   | Unsafe sysctls                                        |
+| PSS - Restricted | [M-111](/internal/builtins/pss/restricted/M-111_volume_types.yml)                   | Low      | Not allowed volume type                               |
+|                  | [M-112](/internal/builtins/pss/restricted/M-112_privilege_escalation.yml)           | Medium   | Allowed privilege escalation                          |
+|                  | [M-113](/internal/builtins/pss/restricted/M-113_run_as_non_root.yml)                | Medium   | Container could be running as root user               |
+|                  | [M-114](/internal/builtins/pss/restricted/M-114_run_as_user.yml)                    | Medium   | Container running as root UID                         |
+|                  | [M-115](/internal/builtins/pss/restricted/M-115_seccomp.yml)                        | Low      | Not allowed seccomp profile                           |
+|                  | [M-116](/internal/builtins/pss/restricted/M-116_capabilities.yml)                   | Low      | Not allowed added/dropped capabilities                |

--- a/checks.md
+++ b/checks.md
@@ -36,6 +36,6 @@ In the table below, you can view all checks present on Marvin. Click on the #ID 
 | PSS - Restricted | [M-111](/internal/builtins/pss/restricted/M-111_volume_types.yml)        | Low      | Not allowed volume type                               |
 |                  | [M-112](/internal/builtins/pss/restricted/M-112_privilege_escalation.yml)| Medium   | Allowed privilege escalation                          |
 |                  | [M-113](/internal/builtins/pss/restricted/M-113_run_as_non_root.yml)     | Medium   | Container could be running as root user               |
-|                  | [M-114](/internal/builtins/pss/restricted/M-114_run_as_user.yml)         | Low      | Container running as root UID                         |
+|                  | [M-114](/internal/builtins/pss/restricted/M-114_run_as_user.yml)         | Medium   | Container running as root UID                         |
 |                  | [M-115](/internal/builtins/pss/restricted/M-115_seccomp.yml)             | Low      | Not allowed seccomp profile                           |
 |                  | [M-116](/internal/builtins/pss/restricted/M-116_capabilities.yml)        | Low      | Not allowed added/dropped capabilities                |

--- a/internal/builtins/pss/restricted/M-113_run_as_non_root.yml
+++ b/internal/builtins/pss/restricted/M-113_run_as_non_root.yml
@@ -43,8 +43,13 @@ match:
       version: v1
       resource: jobs
 variables:
+  # pod-level runAsNonRoot is explicitly set to true
   - name: podRunAsNonRoot
     expression: podSpec.?securityContext.?runAsNonRoot.orValue(false)
+
+  # pod-level runAsUser is explicitly set to non-zero
+  - name: podRunAsNonZeroUser
+    expression: podSpec.?securityContext.?runAsUser.orValue(0) != 0
 
   # containers that explicitly set runAsNonRoot=false
   - name: explicitlyBadContainers
@@ -53,11 +58,16 @@ variables:
           has(c.securityContext) && has(c.securityContext.runAsNonRoot) && c.securityContext.runAsNonRoot == false
       )
 
-  # containers that didn't set runAsNonRoot and aren't caught by a pod-level runAsNonRoot=true
+  # containers that
+  # - didn't set runAsNonRoot
+  # - aren't caught by a pod-level runAsNonRoot=true
+  # - didn't set non-zero runAsUser
+  # - aren't caught by a pod-level non-zero runAsUser
   - name: implicitlyBadContainers
     expression: >
       allContainers.filter(c,
-          !variables.podRunAsNonRoot && (!has(c.securityContext) || !has(c.securityContext.runAsNonRoot)) 
+          (!variables.podRunAsNonRoot && (!has(c.securityContext) || !has(c.securityContext.runAsNonRoot))) &&
+          (!variables.podRunAsNonZeroUser && c.?securityContext.?runAsUser.orValue(0) == 0)
       )
 
 validations:

--- a/internal/builtins/pss/restricted/M-113_run_as_non_root.yml
+++ b/internal/builtins/pss/restricted/M-113_run_as_non_root.yml
@@ -55,7 +55,7 @@ variables:
   - name: explicitlyBadContainers
     expression: >
       allContainers.filter(c,
-          has(c.securityContext) && has(c.securityContext.runAsNonRoot) && c.securityContext.runAsNonRoot == false
+          c.?securityContext.?runAsNonRoot.orValue(null) == false
       )
 
   # containers that
@@ -66,7 +66,7 @@ variables:
   - name: implicitlyBadContainers
     expression: >
       allContainers.filter(c,
-          (!variables.podRunAsNonRoot && (!has(c.securityContext) || !has(c.securityContext.runAsNonRoot))) &&
+          (!variables.podRunAsNonRoot && c.?securityContext.?runAsNonRoot.orValue(null) == null) &&
           (!variables.podRunAsNonZeroUser && c.?securityContext.?runAsUser.orValue(0) == 0)
       )
 

--- a/internal/builtins/pss/restricted/M-113_run_as_non_root_test.yml
+++ b/internal/builtins/pss/restricted/M-113_run_as_non_root_test.yml
@@ -151,3 +151,35 @@
       selector:
         matchLabels:
           app: nginx
+
+- name: "Pod set runAsUser to non-zero"
+  pass: true
+  input: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      securityContext:
+        runAsUser: 1
+      containers:
+        - name: nginx
+          image: nginx
+
+- name: "container set runAsUser to non-zero"
+  pass: true
+  input: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx
+          securityContext:
+            runAsUser: 1

--- a/internal/builtins/pss/restricted/M-114_run_as_user.yml
+++ b/internal/builtins/pss/restricted/M-114_run_as_user.yml
@@ -17,7 +17,7 @@
 # https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/pod-security-admission/policy/check_runAsUser_test.go
 id: M-114
 slug: run-as-user
-severity: Low
+severity: Medium
 message: "Container running as root UID"
 match:
   resources:


### PR DESCRIPTION
## Description
This PR updates the rule of `M-113` `Container could be running as root user` to check non-zero `runAsUser` and increase the severity of `M-114` to `Medium`.

## How has this been tested?
- Running unit tests: `make test`
- Scanning a cluster: `go run main.go scan`

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
