### PR TITLE
fix: handle compile errors

### DIFF
--- a/pkg/validator/compiler.go
+++ b/pkg/validator/compiler.go
@@ -70,8 +70,14 @@ func Compile(check types.Check, apiResources []*metav1.APIResourceList, kubeVers
 	}
 
 	variables, err := compileVariables(env, check.Variables)
+	if err != nil {
+		return nil, err
+	}
 
 	prgs, err := compileValidations(env, check.Validations)
+	if err != nil {
+		return nil, err
+	}
 
 	apiVersions := make([]string, 0, len(apiResources))
 	for _, resource := range apiResources {

--- a/pkg/validator/compiler_test.go
+++ b/pkg/validator/compiler_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Undistro Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package validator
 
 import (

--- a/pkg/validator/compiler_test.go
+++ b/pkg/validator/compiler_test.go
@@ -1,0 +1,99 @@
+package validator
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/undistro/marvin/pkg/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/version"
+)
+
+func TestCompile(t *testing.T) {
+	var apiResources []*metav1.APIResourceList
+	kubeVersion := &version.Info{Major: "1", Minor: "29", GitVersion: "v1.29.2"}
+	podsMatch := types.Match{Resources: []types.ResourceRule{{
+		Group:    "",
+		Version:  "v1",
+		Resource: "pods",
+	}}}
+
+	tests := []struct {
+		check   types.Check
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			check: types.Check{
+				ID:    "ok",
+				Match: podsMatch,
+				Validations: []types.Validation{{
+					Expression: `variables.isWindows || allContainers.size() > 0`,
+				}},
+				Variables: []types.Variable{{
+					Name:       "isWindows",
+					Expression: `podSpec.?os.?name.orValue("") == "windows"`,
+				}},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			check: types.Check{
+				ID:    "validation error",
+				Match: podsMatch,
+				Validations: []types.Validation{{
+					Expression: `allContainers.sizeX() > 0`,
+				}},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			check: types.Check{
+				ID:    "variable error",
+				Match: podsMatch,
+				Validations: []types.Validation{{
+					Expression: `variables.isWindows || allContainers.size() > 0`,
+				}},
+				Variables: []types.Variable{{
+					Name:       "isWindows",
+					Expression: `foo`,
+				}},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			check: types.Check{
+				ID: "no workload",
+				Match: types.Match{Resources: []types.ResourceRule{{
+					Group:    "",
+					Version:  "v1",
+					Resource: "configmaps",
+				}}},
+				Validations: []types.Validation{{
+					Expression: `allContainers.size() > 0`,
+				}},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			check: types.Check{
+				ID:          "no validations",
+				Match:       podsMatch,
+				Validations: nil,
+				Variables: []types.Variable{{
+					Name:       "isWindows",
+					Expression: `podSpec.?os.?name.orValue("") == "windows"`,
+				}},
+			},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.check.ID, func(t *testing.T) {
+			_, err := Compile(tt.check, apiResources, kubeVersion)
+			if !tt.wantErr(t, err, fmt.Sprintf("Compile(%v, %v, %v)", tt.check, apiResources, kubeVersion)) {
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR handles compilation errors of `validations` and `variables` and implements unit test for `Compile` function.

## How has this been tested?
- Running the unit tests: `make test`
- Scanning with a custom check with invalid variable or validation:
```
cat << 'EOF' > tmp/check.yaml
id: test
severity: High
message: "invalid validation"
match:
  resources:
    - group: ""
      version: v1
      resource: pods
validations:
  - expression: allContainers.all(variables.foo)
EOF
go run main.go scan --disable-builtin --checks /tmp/check.yaml 
```
Now we expect to see an error like this:
```
E0318 17:03:19.731543   54820 scan.go:218] "msg"="failed to compile check test" "error"="validations[0].expression: type-check error: ERROR: <input>:1:18: undeclared reference to 'all' (in container '')\n | allContainers.all(variables.test)\n | .................^\nERROR: <input>:1:19: undeclared reference to 'variables' (in container '')\n | allContainers.all(variables.test)\n | ..................^" "check"="test"
I0318 17:03:19.731708   54820 scan.go:186] "msg"="scan finished with errors" 
SEVERITY   ID     CHECK                STATUS   FAILED   PASSED   SKIPPED 
High       test   invalid validation   ERROR    0        0        0         
exit status 2
```
## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
