### PR TITLE
run apk upgrade in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
     -X github.com/undistro/marvin/pkg/version.date=${DATE}" -a -o marvin main.go
 
 FROM alpine:3.19.1
-
+RUN apk upgrade && rm /var/cache/apk/*
 RUN addgroup -g 8494 -S nonroot && adduser -u 8494 -D -S nonroot -G nonroot
 USER 8494:8494
 


### PR DESCRIPTION
## Description
This PR adds a layer in Dockerfile for running `apk upgrade` to fix known vulnerabilities.

```shell
TAG=test make docker-build
trivy image ghcr.io/undistro/marvin:test --scanners vuln --vuln-type os
```
```
2024-04-26T15:44:39.295-0300    INFO    Vulnerability scanning is enabled
2024-04-26T15:44:40.105-0300    INFO    Detected OS: alpine
2024-04-26T15:44:40.106-0300    INFO    Detecting Alpine vulnerabilities...

ghcr.io/undistro/marvin:test (alpine 3.19.1)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

## How has this been tested?
- `make docker-build`

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
