### PR TITLE
fix: update Go version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION


### PR DESCRIPTION
## Description
This PR updates the Go version in Dockerfile to be the same as `go.mod`

## How has this been tested?
https://github.com/undistro/marvin/actions/runs/10167413726/job/28119768990

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
