### PR TITLE
bump alpine base image version from 3.19.1 to 3.20.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22 as builder
+FROM golang:1.22 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION
@@ -34,7 +34,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
     -X github.com/undistro/marvin/pkg/version.commit=${COMMIT} \
     -X github.com/undistro/marvin/pkg/version.date=${DATE}" -a -o marvin main.go
 
-FROM alpine:3.19.1
+FROM alpine:3.20.3
 RUN apk upgrade && rm /var/cache/apk/*
 RUN addgroup -g 8494 -S nonroot && adduser -u 8494 -D -S nonroot -G nonroot
 USER 8494:8494


### PR DESCRIPTION
## Description
This PR bumps alpine base image version from 3.19.1 to 3.20.3 and fixes two low vulnerabilities as you can see below.

```
trivy image ghcr.io/undistro/marvin:v0.2 --scanners vuln
2024-10-25T10:49:18-03:00	INFO	Vulnerability scanning is enabled
2024-10-25T10:49:20-03:00	INFO	Detected OS	family="alpine" version="3.19.1"
2024-10-25T10:49:20-03:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.19" repository="3.19" pkg_num=15
2024-10-25T10:49:20-03:00	INFO	Number of language-specific files	num=1
2024-10-25T10:49:20-03:00	INFO	[gobinary] Detecting vulnerabilities...

ghcr.io/undistro/marvin:v0.2 (alpine 3.19.1)

Total: 2 (UNKNOWN: 0, LOW: 2, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                           │
├────────────┼───────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2024-9143 │ LOW      │ fixed  │ 3.1.7-r0          │ 3.1.7-r1      │ openssl: Low-level invalid GF(2^m) parameters lead to OOB │
│            │               │          │        │                   │               │ memory access                                             │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-9143                 │
├────────────┤               │          │        │                   │               │                                                           │
│ libssl3    │               │          │        │                   │               │                                                           │
│            │               │          │        │                   │               │                                                           │
│            │               │          │        │                   │               │                                                           │
└────────────┴───────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘
```

```
TAG=test make docker-build 

trivy image ghcr.io/undistro/marvin:test --scanners vuln
2024-10-25T10:51:25-03:00       INFO    Vulnerability scanning is enabled
2024-10-25T10:51:26-03:00       INFO    Detected OS     family="alpine" version="3.20.3"
2024-10-25T10:51:26-03:00       INFO    [alpine] Detecting vulnerabilities...   os_version="3.20" repository="3.20" pkg_num=14
2024-10-25T10:51:26-03:00       INFO    Number of language-specific files       num=1
2024-10-25T10:51:26-03:00       INFO    [gobinary] Detecting vulnerabilities...

ghcr.io/undistro/marvin:test (alpine 3.20.3)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

## Linked Issues


## How has this been tested?
- `TAG=test make docker-build `
- `trivy image ghcr.io/undistro/marvin:test --scanners vuln`

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
