### PR TITLE
feat: add --cost-limit flag

### DIFF
--- a/pkg/validator/compiler_test.go
+++ b/pkg/validator/compiler_test.go
@@ -104,7 +104,7 @@ func TestCompile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.check.ID, func(t *testing.T) {
-			_, err := Compile(tt.check, apiResources, kubeVersion)
+			_, err := Compile(tt.check, apiResources, kubeVersion, 1000000)
 			if !tt.wantErr(t, err, fmt.Sprintf("Compile(%v, %v, %v)", tt.check, apiResources, kubeVersion)) {
 				return
 			}

--- a/test/builtins_test.go
+++ b/test/builtins_test.go
@@ -36,7 +36,7 @@ func TestBuiltinChecks(t *testing.T) {
 			assert.True(t, ok)
 			assert.NotNil(t, check)
 			assert.NotEmpty(t, check.ID)
-			v, err := validator.Compile(check, nil, nil)
+			v, err := validator.Compile(check, nil, nil, 1000000)
 			assert.NoError(t, err)
 			assert.NotNil(t, v)
 			for _, tt := range checkTests {


### PR DESCRIPTION
## Description
This PR adds the `--cost-limit` option with disabling support.

## Linked Issues
Marvin fails when scanning a large ConfigMap.

## How has this been tested?
1. Create a large ConfigMap:
    ```
    head -c 1048576 </dev/urandom | base64 | head -c 950000 > configmap-data.txt
    kubectl create configmap large-configmap --from-file=configmap-data.txt
    ```
2. Scan the current cluster:
    ```
    go run main.go scan
    ```
    Marvin will exit with a non-zero code and log the following errors:
    ```
    E0221 13:18:46.238360 2182897 scan.go:236] "msg"="failed to validate check M-201" "error"="evaluate error: operation cancelled: actual cost limit exceeded" "check"="M-201" "obj"="v1/ConfigMap/default/large-configmap"
    I0221 13:18:46.583668 2182897 scan.go:186] "msg"="scan finished with errors" 
    ```
3. Scan the cluster disabling the cost limit:
    ```
    go run main.go scan --cost-limit=0
    ```
    Marvin will finish successfully.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
